### PR TITLE
rework port check and add single torrent option

### DIFF
--- a/trackerfraese.py
+++ b/trackerfraese.py
@@ -8,6 +8,7 @@ import socket
 import struct
 
 server = ServerProxy("http://localhost:8000")
+processedTrackers = dict()
 
 def check_udp_tracker(host,port):
     clisocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
@@ -37,7 +38,6 @@ def check_http_port(host, port):
         a_socket.close()
 
 def process_torrent(torrent):
-    processedTrackers = dict()
     trackerindex = 0
     print("------------------------------------")
     print(server.d.name(torrent))

--- a/trackerfraese.py
+++ b/trackerfraese.py
@@ -1,22 +1,50 @@
 #!/usr/bin/python3
-import pprint
 from xmlrpc.client import ServerProxy, Error
+import argparse
 import dnsq
 import re
 import os
-processedTrackers = dict()
+import socket
+import struct
 
 server = ServerProxy("http://localhost:8000")
 
-for torrent in server.download_list():
+def check_udp_tracker(host,port):
+    clisocket = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    clisocket.settimeout(1.0)
+    connection_id=0x41727101980
+    transaction_id = 12345
+    action = 0x0
+    buffer = struct.pack("!q", connection_id)  # first 8 bytes is connection id
+    buffer += struct.pack("!i", action)  # next 4 bytes is action
+    buffer += struct.pack("!i", transaction_id)  # next 4 bytes is transaction id
+    clisocket.sendto(buffer, (host, port))
+    try:
+        res = clisocket.recv(1024)
+        return res
+    except socket.timeout:
+        return False
+
+def check_http_port(host, port):
+    a_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    a_socket.settimeout(1.0)
+    try:
+        if a_socket.connect_ex((host,port)) == 0:
+            return True
+    except Exception:
+        return False
+    finally:
+        a_socket.close()
+
+def process_torrent(torrent):
+    processedTrackers = dict()
     trackerindex = 0
     print("------------------------------------")
     print(server.d.name(torrent))
     for tracker in server.t.multicall(torrent, "", "t.url="):
-    
+
         tracker = str(tracker.pop())
-#        pprint.pprint(tracker)
-        
+
         if tracker not in processedTrackers:
             rgx1 = r"\/\/([a-zAZ0-9\.\-]*)[\:0-9]*"
             rgx2 = r"\:([0-9]{2,5})"
@@ -28,9 +56,9 @@ for torrent in server.download_list():
             if protocol == 'dht':
               print("skipping dht")
               continue
-            
+
             host = result.group(1)
-             
+
             try:
                 port = result2.group(1)
             except:
@@ -46,33 +74,22 @@ for torrent in server.download_list():
                 print("resolvable, ip is "+ip, end=" - ")
 
                 if protocol == 'udp':
-                
-                    res = os.system("nc -w 3 -vnzu "+ip+" "+str(port)+" > /dev/null 2>&1")
-                    if res == 0:
+
+                    res = check_udp_tracker(ip,int(port))
+                    if res:
                         status = True
                         print("port alive", end=" - ")
                     else:
                         status = False
                         print("port dead", end=" - ")
-                elif protocol == 'http':
-
-                    res = os.system("nc -w 3 -vnz "+ip+" "+str(port)+" > /dev/null 2>&1")
-                    if res == 0:
+                else:
+                    res = check_http_port(ip,port)
+                    if res:
                         status = True
                         print("port alive", end=" - ")
                     else:
                         status = False
-                        print("port dead", end=" - ")        
-                elif protocol == 'https':
-
-                    res = os.system("nc -w 3 -vnz "+ip+" "+str(port)+" > /dev/null 2>&1")
-                    if res == 0:
-                        status = True
-                        print("port alive", end=" - ")
-                    else:
-                        status = False
-                        print("port dead", end=" - ")      
-                
+                        print("port dead", end=" - ")
             else:
                 # print("Tracker with index %d protocol %s host %s port %s" % (trackerindex, protocol, host, port), end=" - ")
 
@@ -89,8 +106,26 @@ for torrent in server.download_list():
             print("Disabling tracker")
             server.t.disable(torrent+":t"+str(trackerindex))
         trackerindex += 1
-        
+
         if tracker not in processedTrackers:
             processedTrackers[tracker] = status
 
     print("------------------------------------")
+
+def parse_args():
+    parser = argparse.ArgumentParser(description='DESCRIPTION')
+    parser.add_argument('torrents', default=[], nargs='*')
+    return parser.parse_args()
+
+def get_from_api():
+    return server.download_list()
+
+def main():
+    args = parse_args()
+
+    for torrent_id in (args.torrents or get_from_api()):
+        process_torrent(torrent_id)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Hello, i've found your script to solve my rtorrent option pretty good.

There was an issue with port checking, since i use rtorrent on my router
and busybox netcat version doesn't support timeout and other stuff.

So i've changed netcat port check to native socket check.
I believe it is more reliable for udp trackers, since i send them proper request.

I successfully used the script with scheduled rtorrent command like
`schedule2 = clean_trackers,10,1800, "execute.capture_nothrow=python,/opt/etc/rtorrent/trackerfraese.py"`

But i still wanted to quickly fix trackers for newly added torrents, so i've added support for second argument,
and now you can add to rtorrent.conf
`method.set_key = event.download.inserted_new,whatever,"execute.nothrow=python,/opt/etc/rtorrent/trackerfraese.py,$d.hash="` 
and it'll fix trackers for new torrent right away. 